### PR TITLE
Added Option for Installing master version via --version flag in Installer Script

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -71,7 +71,7 @@ checkDesiredVersion() {
 
   # Get tag using github api
   local api_release_tags="https://api.github.com/repos/litmuschaos/m-agent/tags"
-    
+
   if [ "${HAS_CURL}" == "true" ]; then
     TAGS=$(curl -Ls $api_release_tags | grep '"name":' | awk '{print $2}' | tr -d '"' | tr -d "v" | tr -d ",")
   elif [ "${HAS_WGET}" == "true" ]; then
@@ -87,7 +87,7 @@ checkDesiredVersion() {
       TAG=$(echo $TAGS | head -1)
     fi
   else
-    if [[ $TAGS == *"$DESIRED_VERSION"* ]]; then
+    if [[ $TAGS == *"$DESIRED_VERSION"* ]] || [[ $DESIRED_VERSION == "master" ]]; then
       TAG=$DESIRED_VERSION
     else
       echo "$DESIRED_VERSION not found"


### PR DESCRIPTION
Signed-off-by: Neelanjan Manna <neelanjan.manna@harness.io>

## What This PR Does
Adds the option for specifying the `master` version using the `--version` CLI flag in the installer shell script.

## Which Issue This PR Fixes
fixes #11

**Checklist:**
-   [x] Fixes #<issue number>
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests
-   [ ] E2E run Required for the changes